### PR TITLE
Update RegressionTestHelper.groovy for line endings issue on comparison

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/RegressionTestHelper.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/RegressionTestHelper.groovy
@@ -35,7 +35,7 @@ class RegressionTestHelper {
         }
 
         String callStack = helper.callStack.join('\n') + '\n'
-        assertThat(callStack).isEqualTo(referenceFile.text)
+        assertThat(callStack.normalize()).isEqualTo(referenceFile.text.normalize())
     }
 
     /**


### PR DESCRIPTION
Normalize line endings when comparing the call stack string representations for regressions in testNonRegression. Otherwise when the callstack file is generated on a Windows system the comparison fails due to different line endings in the file and the generated callstack string.